### PR TITLE
feat(dispatch): rename maestro-apply to agamemnon-apply

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ Dagger calls are made via `dagger call <function> --<args>` from the justfile.
 
 1. AchaeanFleet pushes an image and sends `repository_dispatch` (type: `image-pushed`) to ProjectProteus.
 2. `cross-repo-dispatch.yml` receives the event and calls `scripts/dispatch-apply.sh`.
-3. `dispatch-apply.sh` sends a `repository_dispatch` (type: `maestro-apply`) to Myrmidons.
+3. `dispatch-apply.sh` sends a `repository_dispatch` (type: `agamemnon-apply`) to Myrmidons.
 4. Myrmidons runs `just apply` on the target host.
 
 ### Image Promotion Flow

--- a/scripts/dispatch-apply.sh
+++ b/scripts/dispatch-apply.sh
@@ -14,7 +14,7 @@ if [[ -z "${GITHUB_TOKEN:-}" ]]; then
     exit 1
 fi
 
-echo "Dispatching maestro-apply to ${MYRMIDONS_REPO} for host: ${HOST}"
+echo "Dispatching agamemnon-apply to ${MYRMIDONS_REPO} for host: ${HOST}"
 
 RESPONSE=$(curl --silent --write-out "\n%{http_code}" \
     --request POST \
@@ -22,7 +22,7 @@ RESPONSE=$(curl --silent --write-out "\n%{http_code}" \
     --header "Accept: application/vnd.github+json" \
     --header "Authorization: Bearer ${GITHUB_TOKEN}" \
     --header "X-GitHub-Api-Version: 2022-11-28" \
-    --data "{\"event_type\":\"maestro-apply\",\"client_payload\":{\"host\":\"${HOST}\"}}")
+    --data "{\"event_type\":\"agamemnon-apply\",\"client_payload\":{\"host\":\"${HOST}\"}}")
 
 HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
 BODY=$(echo "$RESPONSE" | head -n-1)


### PR DESCRIPTION
## Summary
- Rename `maestro-apply` repository_dispatch event type to `agamemnon-apply` in all dispatch scripts and pipelines
- Matches Myrmidons repo migration (PR #59) which now listens for `agamemnon-apply`
- Part of ADR-006: full decoupling from ai-maestro

## Test plan
- [ ] `scripts/dispatch-apply.sh` sends `agamemnon-apply` event type
- [ ] No remaining `maestro` references in dispatch chain
- [ ] Myrmidons `apply.yml` workflow triggers correctly on `agamemnon-apply`

🤖 Generated with Claude Code