### PR TITLE
feat(justfile): add bootstrap and check recipes for Odysseus delegation

### DIFF
--- a/justfile
+++ b/justfile
@@ -50,12 +50,23 @@ dispatch-apply HOST:
     GITHUB_TOKEN={{GITHUB_TOKEN}} MYRMIDONS_REPO={{MYRMIDONS_REPO}} ./scripts/dispatch-apply.sh {{HOST}}
 
 # ===========================
+# Setup
+# ===========================
+
+# Install pixi environment
+bootstrap:
+    pixi install
+
+# ===========================
 # Quality
 # ===========================
 
 # Run lint checks via Dagger
 lint:
     dagger call lint --source .
+
+# Run lint + validate together
+check: lint validate
 
 # Validate all pipeline configs in configs/pipelines/
 validate:


### PR DESCRIPTION
## Summary

- Adds `bootstrap` recipe that runs `pixi install` to set up the pixi environment (pixi.toml already exists)
- Adds `check` composite recipe that runs `lint` + `validate` together for a single quality-gate command
- All existing recipes (default, build, test, pipeline, promote, dispatch-apply, lint, validate) are unchanged
- `just --list` now shows 10 recipes total, all with docstrings

Part of HomericIntelligence/Odysseus#8

## Test plan

- [ ] `just --list` shows all 10 recipes without errors
- [ ] `just bootstrap` runs `pixi install` in a fresh clone
- [ ] `just check` runs lint then validate in sequence and fails fast on first error

🤖 Generated with [Claude Code](https://claude.com/claude-code)