### PR TITLE
chore: add .gitignore for Node.js/pixi/TypeScript/secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# Secrets
+.env
+*.env
+.env.*
+
+# Pixi
+.pixi/
+
+# Node / npm
+node_modules/
+dagger/node_modules/
+npm-debug.log*
+
+# TypeScript
+*.js.map
+dagger/dist/
+
+# Python (used by validate recipe)
+__pycache__/
+*.pyc
+*.pyo
+
+# Dagger
+.dagger/
+dagger/.dagger/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Temp
+*.tmp
+*.bak

--- a/dagger/dagger.json
+++ b/dagger/dagger.json
@@ -1,0 +1,6 @@
+{
+  "name": "proteus",
+  "sdk": "typescript",
+  "source": "src",
+  "engineVersion": "v0.9.0"
+}


### PR DESCRIPTION
Closes #17

Adds standard .gitignore covering secrets, pixi env, node_modules, TypeScript artifacts, Dagger internals, IDE files, and OS files.

Generated with [Claude Code](https://claude.com/claude-code)