### PR TITLE
fix(scripts): add curl timeout and retry logic to dispatch-apply.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to ProjectProteus will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Initial CI/CD pipeline hub scaffold with Dagger TypeScript SDK
+- `Proteus` Dagger module with `build`, `test`, and `lint` pipeline functions
+- Cross-repo dispatch workflow (`cross-repo-dispatch.yml`) bridging AchaeanFleet → Myrmidons
+- Image promotion workflow (`promote.yml`) with manual trigger
+- `scripts/promote-image.sh` — skopeo-based image promotion wrapper
+- `scripts/dispatch-apply.sh` — GitHub API repository_dispatch sender
+- Pipeline configuration schema in `configs/pipelines/`
+- `justfile` task runner with `build`, `test`, `lint`, `validate`, `pipeline`, `promote`, and `dispatch-apply` recipes
+- `pixi.toml` environment management
+- LICENSE, CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ProjectProteus
 
+[![CI](https://github.com/HomericIntelligence/ProjectProteus/actions/workflows/ci.yml/badge.svg)](https://github.com/HomericIntelligence/ProjectProteus/actions/workflows/ci.yml)
+
 CI/CD pipeline automation hub for the HomericIntelligence ecosystem.
 
 ## Purpose

--- a/scripts/dispatch-apply.sh
+++ b/scripts/dispatch-apply.sh
@@ -16,7 +16,7 @@ fi
 
 echo "Dispatching agamemnon-apply to ${MYRMIDONS_REPO} for host: ${HOST}"
 
-RESPONSE=$(curl --silent --write-out "\n%{http_code}" \
+RESPONSE=$(curl --silent --connect-timeout 10 --max-time 30 --retry 3 --retry-delay 2 --write-out "\n%{http_code}" \
     --request POST \
     --url "https://api.github.com/repos/${MYRMIDONS_REPO}/dispatches" \
     --header "Accept: application/vnd.github+json" \


### PR DESCRIPTION
Closes #24

Adds `--connect-timeout 10 --max-time 30 --retry 3 --retry-delay 2` to the curl call in `scripts/dispatch-apply.sh` to prevent the script from hanging indefinitely on network failures and to retry transient GitHub API errors.

Generated with [Claude Code](https://claude.com/claude-code)