### PR TITLE
feat(dagger): add publish parameter to build() for dry-run support

### DIFF
--- a/dagger/src/index.ts
+++ b/dagger/src/index.ts
@@ -5,21 +5,28 @@ export class Proteus {
   /**
    * Build an OCI image from a Dockerfile in the given context directory.
    * Returns the image digest.
+   * @param publish - Whether to push the image to the registry (default: true)
    */
   @func()
   async build(
     context: Directory,
     name: string,
     tag: string = "latest",
-    registry: string = "ghcr.io/homeric-intelligence"
+    registry: string = "ghcr.io/homeric-intelligence",
+    publish: boolean = true
   ): Promise<string> {
     const ref = `${registry}/${name}:${tag}`
     const image = dag
       .container()
       .build(context)
 
-    const published = await image.publish(ref)
-    return published
+    if (publish) {
+      const published = await image.publish(ref)
+      return published
+    } else {
+      const digest = await image.id()
+      return digest
+    }
   }
 
   /**


### PR DESCRIPTION
Closes #14

Adds an optional `publish: boolean = true` parameter to the `build()` function. When `publish` is `false`, the image is built but not pushed to the registry — enabling dry-run/validation builds without side effects. Existing callers are unaffected (default is `true`).

Generated with [Claude Code](https://claude.com/claude-code)