### PR TITLE
chore: add .editorconfig and pre-commit hooks configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,31 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.ts]
+indent_size = 2
+
+[*.sh]
+indent_size = 2
+
+[*.yml]
+indent_size = 2
+
+[*.yaml]
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[justfile]
+indent_style = space
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+        exclude: '\.md$'
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+      - id: check-merge-conflict
+      - id: mixed-line-ending
+        args: [--fix=lf]
+
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        args: [--severity=warning]
+
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.35.1
+    hooks:
+      - id: yamllint
+        args: [-d, '{extends: relaxed, rules: {line-length: {max: 120}}}']


### PR DESCRIPTION
Closes #25

Adds developer experience tooling:

**`.editorconfig`** — consistent formatting rules across editors for TypeScript, shell scripts, YAML, Markdown, and justfiles.

**`.pre-commit-config.yaml`** — pre-commit hooks using the [pre-commit framework](https://pre-commit.com):
- `trailing-whitespace` — removes trailing spaces (excludes .md)
- `end-of-file-fixer` — ensures files end with a newline
- `check-yaml` / `check-json` — validates syntax
- `check-merge-conflict` — catches unresolved conflict markers
- `mixed-line-ending` — normalizes to LF
- `shellcheck` (warning level) — lints shell scripts
- `yamllint` — validates YAML style

Run `pip install pre-commit && pre-commit install` to activate locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)