### PR TITLE
feat(scripts): add post-promotion smoke test to promote-image.sh

### DIFF
--- a/scripts/promote-image.sh
+++ b/scripts/promote-image.sh
@@ -26,4 +26,12 @@ fi
 
 skopeo copy "docker://${SRC}" "docker://${DEST}"
 
-echo "Promotion complete: ${DEST}"
+echo "Verifying promotion to ${DEST}..."
+DEST_DIGEST=$(skopeo inspect "docker://${DEST}" --format '{{.Digest}}' 2>/dev/null) || {
+    echo "ERROR: Post-promotion verification failed — destination image not found or not accessible: ${DEST}" >&2
+    exit 1
+}
+echo "Promotion verified successfully."
+echo "  Source:      ${SRC}"
+echo "  Destination: ${DEST}"
+echo "  Digest:      ${DEST_DIGEST}"


### PR DESCRIPTION
Closes #37

Adds a post-promotion verification step to `scripts/promote-image.sh`:

1. After `skopeo copy` completes, runs `skopeo inspect` on the **destination** image
2. If the destination is not accessible, exits with a clear error message
3. On success, prints the verified digest for audit traceability

This ensures promotions are confirmed end-to-end rather than relying solely on `skopeo copy` exit code (which may succeed even if the push is not immediately visible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)