### PR TITLE
ci: replace GHCR_TOKEN with GITHUB_TOKEN in promote workflow

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -38,11 +38,12 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y skopeo
 
       - name: Log in to registry
+        # GITHUB_TOKEN has packages: write permission (set above) — no PAT needed for GHCR
         env:
-          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTOR: ${{ github.actor }}
         run: |
-          echo "${GHCR_TOKEN}" | skopeo login ghcr.io \
+          echo "${GITHUB_TOKEN}" | skopeo login ghcr.io \
             --username "${ACTOR}" \
             --password-stdin
 


### PR DESCRIPTION
Closes #40

The \`promote.yml\` workflow already has \`permissions: packages: write\` (added in PR #60), which grants \`GITHUB_TOKEN\` write access to GHCR for the HomericIntelligence organization. A separate \`GHCR_TOKEN\` PAT is not required.

This change:
- Replaces \`secrets.GHCR_TOKEN\` with \`secrets.GITHUB_TOKEN\` in the registry login step
- Adds a comment explaining why \`GITHUB_TOKEN\` is sufficient
- Removes the dependency on a manually-managed PAT secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)