### PR TITLE
ci: add npm caching and switch to npm ci now that lockfile exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: dagger/package-lock.json
 
       - name: Install dependencies
-        run: cd dagger && npm install
+        run: cd dagger && npm ci
 
       - name: TypeScript type check
         run: cd dagger && npx tsc --noEmit


### PR DESCRIPTION
Closes #43

Now that \`dagger/package-lock.json\` is committed (PR #65 / issue #21):

- Adds \`cache: 'npm'\` and \`cache-dependency-path: dagger/package-lock.json\` to the \`setup-node\` step in the \`typecheck\` job
- Switches \`npm install\` → \`npm ci\` for strict, reproducible installs
- pixi caching already enabled via \`setup-pixi\` with \`cache: true\` (PR #64)

**Note:** This PR should merge after PR #65 (lockfiles) to ensure the cache key resolves correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)