### PR TITLE
chore(license): update copyright year to 2025-2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2025, HomericIntelligence Contributors
+Copyright (c) 2025-2026, HomericIntelligence Contributors
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
## Summary

- Extends BSD-3-Clause copyright line from `2025` to `2025-2026` to reflect the current audit year (2026-04-28)

## Test plan

- [ ] Verify LICENSE line 3 reads `Copyright (c) 2025-2026`

Closes #115