### PR TITLE
chore(claude): add hooks and permission guardrails to settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,30 @@
 {
   "enabledPlugins": {
     "hephaestus@ProjectHephaestus": true
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" && just validate 2>&1 | tail -20"
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(just:*)",
+      "Bash(git:*)",
+      "Bash(gh:*)",
+      "Bash(pixi:*)"
+    ],
+    "deny": [
+      "Bash(rm -rf *)",
+      "Bash(git push --force*)"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- Adds `PostToolUse` hook that runs `just validate` after every file edit for fast feedback
- Adds allow-list restricting agent Bash to `just`, `git`, `gh`, and `pixi` commands (POLA)
- Adds deny-list blocking `rm -rf` and `git push --force` to prevent destructive accidents

## Test plan

- [ ] `.claude/settings.json` is valid JSON
- [ ] Claude Code loads without errors in the repo
- [ ] `just validate` hook fires after an edit

Closes #119