### PR TITLE
chore: easy-issue sweep — refs #108 #109 #110 #114 #117

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- 1-3 bullet points describing what this PR does and why. -->
+
+## Changes
+
+<!-- Optional: list of notable changes (files, modules, behavior). -->
+
+## Test plan
+
+<!-- Checklist of how this was verified. -->
+- [ ] `just lint`
+- [ ] `just validate`
+- [ ] CI is green
+
+## Linked issues
+
+<!-- e.g. Refs #123, Closes #456 -->

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ ProjectProteus/
 │       └── index.ts        # Dagger TypeScript pipeline module
 ├── scripts/
 │   ├── promote-image.sh    # Skopeo image copy helper
-│   └── dispatch-apply.sh   # GitHub API dispatch trigger
+│   ├── dispatch-apply.sh   # GitHub API dispatch trigger
+│   └── check-symlinks.sh   # Verify all repo symlinks resolve
 ├── configs/
 │   └── pipelines/
 │       └── achaean-fleet.yaml  # Per-repo pipeline config
@@ -77,6 +78,14 @@ ProjectProteus/
 ├── CLAUDE.md
 └── README.md
 ```
+
+## Scripts
+
+The `scripts/` directory contains helper utilities used by `just` recipes and CI:
+
+- **`promote-image.sh`** — Copies an OCI image between registries using Skopeo. Invoked by `just promote SRC DEST`. Honors `REGISTRY_USERNAME` / `REGISTRY_PASSWORD` for auth.
+- **`dispatch-apply.sh`** — Sends a `repository_dispatch` event to Myrmidons to trigger an apply against a host. Invoked by `just dispatch-apply HOST`.
+- **`check-symlinks.sh`** — Walks the repo (excluding `.git/`) and fails if any symlink points to a missing target. Run manually or wired into CI to catch broken submodule/config links early.
 
 ## Prerequisites
 

--- a/dagger/package.json
+++ b/dagger/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "typescript": "^6.0.3",
     "ts-node": "^10.9.0",
-    "@types/node": "^25.6.2"
+    "@types/node": "^20.14.0"
   },
   "engines": {
     "node": ">=20"

--- a/justfile
+++ b/justfile
@@ -81,7 +81,7 @@ validate:
 	fi
 	errors=0
 	for f in "${files[@]}"; do
-	    if python3 -c "import yaml; yaml.safe_load(open('$f'))" 2>/dev/null; then
+	    if pixi run python -c "import yaml; yaml.safe_load(open('$f'))" 2>/dev/null; then
 	        echo "  OK: $f"
 	    else
 	        echo "  FAIL: $f"

--- a/scripts/promote-image.sh
+++ b/scripts/promote-image.sh
@@ -1,36 +1,52 @@
 #!/usr/bin/env bash
 # promote-image.sh — Copy an OCI image between registries using skopeo.
-# Usage: ./scripts/promote-image.sh <source-ref> <dest-ref>
+# Usage: ./scripts/promote-image.sh [--quiet] <source-ref> <dest-ref>
 # Example: ./scripts/promote-image.sh ghcr.io/homeric-intelligence/myapp:staging \
 #                                      ghcr.io/homeric-intelligence/myapp:latest
+#
+# Flags:
+#   --quiet  Suppress informational stdout. Errors still go to stderr.
+#            Equivalent to setting PROMOTE_QUIET=1 in the environment.
 #
 # Authentication: set REGISTRY_USERNAME and REGISTRY_PASSWORD env vars for
 # registry auth, or pre-authenticate via 'skopeo login' / 'docker login' before calling.
 
 set -euo pipefail
 
+QUIET="${PROMOTE_QUIET:-0}"
+if [[ "${1:-}" == "--quiet" ]]; then
+    QUIET=1
+    shift
+fi
+
 if [[ $# -ne 2 ]]; then
-    echo "Usage: $0 <source-image-ref> <dest-image-ref>" >&2
+    echo "Usage: $0 [--quiet] <source-image-ref> <dest-image-ref>" >&2
     exit 1
 fi
 
 SRC="$1"
 DEST="$2"
 
+log() {
+    if [[ "${QUIET}" != "1" ]]; then
+        echo "$@"
+    fi
+}
+
 # Optional registry authentication via env vars
 if [[ -n "${REGISTRY_USERNAME:-}" && -n "${REGISTRY_PASSWORD:-}" ]]; then
     REGISTRY=$(echo "${SRC}" | cut -d'/' -f1)
-    echo "Authenticating with registry: ${REGISTRY}"
+    log "Authenticating with registry: ${REGISTRY}"
     echo "${REGISTRY_PASSWORD}" | skopeo login "${REGISTRY}" \
         --username "${REGISTRY_USERNAME}" \
         --password-stdin
 fi
 
-echo "Promoting image:"
-echo "  SRC:  $SRC"
-echo "  DEST: $DEST"
+log "Promoting image:"
+log "  SRC:  $SRC"
+log "  DEST: $DEST"
 
-echo "Verifying source image: ${SRC}"
+log "Verifying source image: ${SRC}"
 if ! skopeo inspect "docker://${SRC}" > /dev/null 2>&1; then
   echo "ERROR: Source image not found or not accessible: ${SRC}" >&2
   exit 1
@@ -38,12 +54,12 @@ fi
 
 skopeo copy "docker://${SRC}" "docker://${DEST}"
 
-echo "Verifying promotion to ${DEST}..."
+log "Verifying promotion to ${DEST}..."
 DEST_DIGEST=$(skopeo inspect "docker://${DEST}" --format '{{.Digest}}' 2>/dev/null) || {
     echo "ERROR: Post-promotion verification failed — destination image not found or not accessible: ${DEST}" >&2
     exit 1
 }
-echo "Promotion verified successfully."
-echo "  Source:      ${SRC}"
-echo "  Destination: ${DEST}"
-echo "  Digest:      ${DEST_DIGEST}"
+log "Promotion verified successfully."
+log "  Source:      ${SRC}"
+log "  Destination: ${DEST}"
+log "  Digest:      ${DEST_DIGEST}"


### PR DESCRIPTION
## Summary

Sweep of five `severity:minor` audit findings in a single small PR. All changes are scoped to docs, build config, and an opt-in flag — no Dagger module API changes.

## Changes

- **Refs #117** — Add a Scripts section to `README.md` documenting `promote-image.sh`, `dispatch-apply.sh`, and `check-symlinks.sh`; also include `check-symlinks.sh` in the repo-structure tree.
- **Refs #114** — `justfile` `validate:` now invokes `pixi run python` so YAML validation uses the pixi-managed interpreter (with `pyyaml` from `[pypi-dependencies]`) instead of system `python3`.
- **Refs #110** — Add `.github/pull_request_template.md` with Summary / Changes / Test plan / Linked issues sections.
- **Refs #109** — `scripts/promote-image.sh` gains a `--quiet` flag (and `PROMOTE_QUIET=1` env var) that suppresses informational stdout while keeping error output on stderr. Default behavior unchanged.
- **Refs #108** — Downgrade `@types/node` from `^25.6.2` to `^20.14.0` to align with `engines.node >=20`.

LOC: ~58 insertions / 15 deletions across 5 files.

## Test plan

- [ ] `just validate` runs under pixi without falling back to system Python
- [ ] `./scripts/promote-image.sh --quiet SRC DEST` is silent on success; errors still surface
- [ ] `./scripts/promote-image.sh SRC DEST` retains existing verbose logging
- [ ] `npm install` in `dagger/` resolves `@types/node@^20`
- [ ] CI is green