### PR TITLE
chore: easy-issue sweep 2026-05-11

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,8 @@ ProjectProteus/
 │   └── tsconfig.json
 ├── scripts/
 │   ├── promote-image.sh    # skopeo copy wrapper
-│   └── dispatch-apply.sh   # GitHub API repository_dispatch sender
+│   ├── dispatch-apply.sh   # GitHub API repository_dispatch sender
+│   └── check-symlinks.sh   # verify all repo symlinks resolve (run in CI symlink-check job)
 ├── configs/
 │   └── pipelines/
 │       └── achaean-fleet.yaml  # Pipeline config for AchaeanFleet

--- a/dagger/package.json
+++ b/dagger/package.json
@@ -11,7 +11,7 @@
     "@dagger.io/dagger": "^0.20.8"
   },
   "devDependencies": {
-    "typescript": "^6.0.3",
+    "typescript": "~6.0.3",
     "ts-node": "^10.9.0",
     "@types/node": "^20.14.0"
   },

--- a/scripts/dispatch-apply.sh
+++ b/scripts/dispatch-apply.sh
@@ -24,8 +24,10 @@ RESPONSE=$(curl --silent --connect-timeout 10 --max-time 30 --retry 3 --retry-de
     --header "X-GitHub-Api-Version: 2022-11-28" \
     --data "{\"event_type\":\"agamemnon-apply\",\"client_payload\":{\"host\":\"${HOST}\"}}")
 
-HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
-BODY=$(echo "$RESPONSE" | head -n-1)
+HTTP_CODE=$(printf '%s' "$RESPONSE" | tail -n1)
+# Use sed to drop the last line (HTTP code) — portable across GNU and BSD
+# (BSD `head` does not support the GNU-only `-n-1` extension).
+BODY=$(printf '%s' "$RESPONSE" | sed '$d')
 
 if [[ "$HTTP_CODE" -eq 204 ]]; then
     echo "Dispatch successful (204 No Content). Myrmidons apply triggered for host: ${HOST}"


### PR DESCRIPTION
## Summary

Continuation of the 2026-05-11 ecosystem-wide easy-issue sweep for ProjectProteus. Implements three small fixes and bundles `Closes` lines for five issues already resolved by PR #135 / PR #136 (which used `Refs` and so left them open).

## Implemented (3 commits)

- **Closes #117** — `CLAUDE.md` repository-structure tree now lists `scripts/check-symlinks.sh` (PR #135 added it to README.md but not CLAUDE.md; the issue title named both files).
- **Closes #104** — `scripts/dispatch-apply.sh` replaces the GNU-only `head -n-1` with portable `sed '$d'`; switches to `printf` for safer separator handling. Now works on BSD/macOS.
- **Closes #107** — `dagger/package.json` tightens `typescript` from `^6.0.3` to `~6.0.3` so Dependabot can only auto-bump patch releases (minor releases routinely change type-system narrowing behaviour and must be reviewed).

## Verified ALREADY-DONE (closing via this PR)

- **Closes #114** — `justfile:84` already invokes `pixi run python -c "import yaml; ..."` (changed in PR #135). System `python3` is no longer used.
- **Closes #110** — `.github/pull_request_template.md` exists with Summary / Changes / Test plan / Linked issues sections (added in PR #135).
- **Closes #109** — `scripts/promote-image.sh` supports `--quiet` and `PROMOTE_QUIET=1` to suppress informational stdout (added in PR #135). Operators in image-ref-disclosure-sensitive contexts can opt in.
- **Closes #108** — `dagger/package.json` pins `@types/node` to `^20.14.0` (downgraded from `^25.x` in PR #135 + #136), aligned with `engines.node: >=20`.

## Skipped — too large for the 50-LoC-per-issue sweep cap

- **#106** — Dedupe `validate` (ci.yml) vs `unit-tests` (_required.yml) YAML validation. The two jobs have different scopes (configs/pipelines/*.yaml vs all *.yaml), so collapsing them is a CI-topology change requiring more thought; defer to a focused PR.
- **#105** — Structured logging across all shell scripts. Requires introducing a logging helper (level/timestamp/JSON) and refactoring every `echo` site.
- **#111** — `AGENTS.md` for cross-repo contracts (event payload schemas, etc.). Needs design work; not a one-line addition.
- **#112** — Backwards-compatibility policy for the Dagger module API. Requires authoring a versioning/migration document.
- **#113** — `.devcontainer/devcontainer.json` for turnkey dev setup. Non-trivial config covering Dagger, skopeo, Node 20, pixi, just.
- **#116** — Operational runbook for cross-repo dispatch failure scenarios. New `docs/runbooks/` doc; needs incident-response material.

## Test plan

- [ ] `just lint`
- [ ] `just validate`
- [ ] `npm install` in `dagger/` resolves `typescript@~6.0.3`
- [ ] `./scripts/dispatch-apply.sh` works on macOS (sed-based last-line drop)
- [ ] CI is green