### PR TITLE
chore: easy-issue sweep bundle (2026-05-16)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+{
+  "name": "ProjectProteus",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/git:1": {}
+  },
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-azuretools.vscode-docker",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "timonwong.shellcheck",
+        "redhat.vscode-yaml"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "files.eol": "\n"
+      }
+    }
+  },
+  "containerEnv": {
+    "PROTEUS_DEV": "1"
+  },
+  "remoteUser": "vscode",
+  "mounts": [
+    "source=${localEnv:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,consistency=cached"
+  ]
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -35,7 +35,7 @@ fi
 
 log "Installing dagger node module dependencies"
 if [ -d /workspaces/ProjectProteus/dagger ]; then
-  (cd /workspaces/ProjectProteus/dagger && npm ci || npm install)
+  ( cd /workspaces/ProjectProteus/dagger && { npm ci || npm install; } )
 fi
 
 log "post-create complete"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Provision ProjectProteus prerequisites inside the devcontainer.
+#
+# Installs: pixi, just, skopeo, shellcheck, Dagger CLI.
+# Used by .devcontainer/devcontainer.json's postCreateCommand.
+
+set -euo pipefail
+
+log() { printf '[post-create] %s\n' "$*"; }
+
+log "Updating apt index"
+sudo apt-get update -y
+
+log "Installing skopeo and shellcheck"
+sudo apt-get install -y --no-install-recommends skopeo shellcheck
+
+log "Installing just"
+if ! command -v just >/dev/null 2>&1; then
+  curl -fsSL --proto '=https' --tlsv1.2 https://just.systems/install.sh \
+    | sudo bash -s -- --to /usr/local/bin
+fi
+
+log "Installing pixi"
+if ! command -v pixi >/dev/null 2>&1; then
+  curl -fsSL https://pixi.sh/install.sh | bash
+  # shellcheck disable=SC2016
+  echo 'export PATH="$HOME/.pixi/bin:$PATH"' >> "$HOME/.bashrc"
+fi
+
+log "Installing Dagger CLI"
+if ! command -v dagger >/dev/null 2>&1; then
+  curl -fsSL https://dl.dagger.io/dagger/install.sh \
+    | BIN_DIR=/usr/local/bin sudo sh
+fi
+
+log "Installing dagger node module dependencies"
+if [ -d /workspaces/ProjectProteus/dagger ]; then
+  (cd /workspaces/ProjectProteus/dagger && npm ci || npm install)
+fi
+
+log "post-create complete"

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install shellcheck
         run: sudo apt-get install -y shellcheck
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: "Reject silent-failure workaround in shell/YAML/Dockerfile/justfile/HCL"
         run: |
@@ -109,7 +109,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install pyyaml
         run: pip install pyyaml
@@ -133,7 +133,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install pyyaml
         run: pip install pyyaml
@@ -154,10 +154,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Trivy filesystem scan
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           scan-type: fs
           scan-ref: .
@@ -169,7 +169,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
@@ -198,7 +198,7 @@ jobs:
 
       - name: Upload Gitleaks SARIF
         if: always() && hashFiles('gitleaks.sarif') != ''
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: gitleaks-report
           path: gitleaks.sarif
@@ -209,7 +209,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Validate shell script shebangs
         run: |
@@ -224,7 +224,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install check-jsonschema
         run: pip install check-jsonschema
@@ -250,7 +250,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Report pinned versions in shell scripts (informational)
         run: |
@@ -307,7 +307,7 @@ jobs:
           fi
       - name: Setup pixi
         if: steps.detect.outputs.skip == 'false'
-        uses: prefix-dev/setup-pixi@v0.9.5
+        uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0  # v0.9.5
         with:
           pixi-version: v0.67.2
           cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,21 +15,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  validate:
-    name: Validate Pipeline Configs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-
-      - name: Set up pixi
-        uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0  # v0.9.5
-        with:
-          pixi-version: v0.67.2
-          cache: true
-
-      - name: Validate pipeline configs
-        run: pixi run just validate
+  # NOTE: a separate `validate` job that ran `pixi run just validate`
+  # previously lived here. It duplicated the `unit-tests` /
+  # `integration-tests` jobs in `_required.yml`, which already YAML-parse
+  # every pipeline config and verify references to workflow names.
+  # Closes #106. If a richer schema validation step is reintroduced,
+  # prefer extending `_required.yml` (single source of truth) rather than
+  # splitting validation across two workflows.
 
   lint-scripts:
     name: Lint Shell Scripts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up pixi
-        uses: prefix-dev/setup-pixi@v0.9.5
+        uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0  # v0.9.5
         with:
           pixi-version: v0.67.2
           cache: true
@@ -36,10 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Run shellcheck
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38  # v2.0.0
         with:
           scandir: "./scripts"
 
@@ -48,10 +48,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903  # v6.0.0
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/cross-repo-dispatch.yml
+++ b/.github/workflows/cross-repo-dispatch.yml
@@ -26,7 +26,7 @@ jobs:
           echo "${CLIENT_PAYLOAD}"
 
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Dispatch apply to Myrmidons
         env:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install skopeo
         run: sudo apt-get update && sudo apt-get install -y skopeo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,75 @@
+# AGENTS.md — ProjectProteus
+
+This document specifies the multi-agent coordination protocols for
+ProjectProteus within the HomericIntelligence distributed agent mesh.
+
+## Role
+
+ProjectProteus is the **CI/CD hub**: it owns the Dagger TypeScript
+module used to build, test, and lint workloads, and it owns the
+GitHub Actions workflows that wire those Dagger pipelines to the rest
+of the ecosystem (notably AchaeanFleet for image pushes and
+Myrmidons for cluster apply via `repository_dispatch`).
+
+```
+AchaeanFleet ──(image-pushed event)──► ProjectProteus ──(dispatch)──► Myrmidons
+                                            │
+                                            ├─► Dagger build / test / lint
+                                            └─► skopeo promote
+```
+
+## Role boundaries
+
+| Agent | Owns | Must not do |
+|---|---|---|
+| ProjectProteus | Dagger module, CI workflows, promote/dispatch glue | apply cluster state directly |
+| ProjectAchaeanFleet | container image build and push | call Dagger functions |
+| Myrmidons | declarative cluster apply | dispatch its own work |
+| ProjectAgamemnon | agent orchestration | drive CI |
+
+## Inbound handoff (Achaeans → Proteus)
+
+AchaeanFleet (or any upstream) sends a `repository_dispatch` event:
+
+```
+event_type: image-pushed
+client_payload:
+  host: <hostname>
+  image: <registry/image>     # advisory; not yet consumed
+  tag:   <tag>                 # advisory; not yet consumed
+```
+
+ProjectProteus reads `client_payload.host` in
+`.github/workflows/cross-repo-dispatch.yml` and invokes
+`scripts/dispatch-apply.sh` to forward the apply request to Myrmidons.
+
+The contract for `client_payload` is currently under-specified — see
+the issue backlog for the payload contract mismatch (#15, #84) and the
+known-defects list in `CLAUDE.md`.
+
+## Outbound handoff (Proteus → Myrmidons)
+
+`scripts/dispatch-apply.sh` issues a Myrmidons `repository_dispatch`
+with the host argument so Myrmidons can apply the declarative state for
+that host.
+
+## Inter-agent message contracts
+
+- GitHub `repository_dispatch` events are the transport.
+- The cross-repo schema is not formally versioned yet; payload
+  evolution is handled in lockstep PRs across the affected repos.
+
+## Coordination invariants
+
+1. **No direct cluster mutation.** Proteus never SSHes; it only
+   dispatches to Myrmidons.
+2. **Idempotent dispatches.** Re-issuing the same `image-pushed` event
+   should not produce side effects beyond a second Myrmidons apply.
+3. **Required CI green before merge.** All workflows pinned by SHA;
+   see `docs/branch-protection.md`.
+
+## See also
+
+- `CLAUDE.md`
+- `docs/runbooks/cross-repo-dispatch-failure.md`
+- `docs/backwards-compat.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,35 @@ Build (dagger call build) → Test (dagger call test) → Promote (skopeo copy) 
 
 This full pipeline is invoked with `just pipeline NAME`.
 
+## Known Critical Defects
+
+The following defects are open and **load-bearing** — agents working in
+this repo should know about them before changing behaviour in the
+affected areas. Always check the linked issue for the current status
+before assuming the defect is unfixed.
+
+- **Cross-repo dispatch payload contract mismatch.** `cross-repo-dispatch.yml`
+  reads `client_payload.host`, but no documented upstream emitter currently
+  sends that field consistently. See #15, #84.
+- **Build/promote tag arithmetic broken.** The build and promote scripts
+  produce incorrect tags in edge cases (multi-arch, no-tag input). See
+  #2, #83.
+- **Pipeline YAML configs are not consumed.** `configs/pipelines/*.yaml`
+  is parsed only by `just validate`; no production code reads it.
+  See #1, #82.
+- **CI unit/integration "jobs" are YAML parsers, not tests.** Until #88
+  / #89 / #5 land, do not rely on the green CI badge as evidence of
+  Dagger function correctness.
+- **GitHub Actions security gaps.** Gitleaks runs with
+  `continue-on-error` (#86); Trivy runs with `exit-code: 0` (#85).
+  Treat absence of a failure as inconclusive.
+- **Branch protection partial.** PRs require zero reviews (#95); no
+  CODEOWNERS enforcement (#102). See `docs/branch-protection.md` for
+  the target state.
+
+Agents must not silently work around these defects; instead, link the
+relevant issue from any PR that touches the affected code.
+
 ## Development Guidelines
 
 - All Dagger functions must be tested locally with `dagger call` before committing.

--- a/docs/backwards-compat.md
+++ b/docs/backwards-compat.md
@@ -1,0 +1,78 @@
+# Backwards Compatibility Policy — Dagger Module API
+
+This document defines what backwards compatibility means for the
+TypeScript Dagger module shipped from `dagger/src/index.ts`.
+
+## Public surface area (governed by SemVer)
+
+1. **The `Proteus` class methods** and their parameter signatures:
+   - `build()`
+   - `test()`
+   - `lint()`
+   - Any additional method exported in `index.ts`.
+2. **Method parameter names, types, defaults, and required/optional status.**
+3. **Return-shape contracts** documented in JSDoc.
+4. **Module name** (`@homeric-intelligence/proteus` once published) and
+   the export structure of the npm package.
+
+## Not public
+
+- Internal helper functions and `_`-prefixed members.
+- The exact text of log output or error messages (structure and exit
+  codes only).
+- Workflow YAML files under `.github/workflows/` (these are this
+  repo's CI, not a downstream contract).
+- Pipeline config schemas under `configs/` (consumed only by Proteus
+  itself for now).
+
+## What counts as breaking
+
+A change is **breaking** if it:
+
+- Removes or renames a public method.
+- Adds a required parameter to a public method.
+- Removes a parameter or tightens its allowed values.
+- Changes a default value in a way that changes runtime behaviour.
+- Changes the return shape in a way that breaks `tsc --noEmit` on a
+  conforming downstream caller.
+- Removes a documented environment variable read by the module.
+
+A change is **non-breaking** if it:
+
+- Adds a new public method.
+- Adds an optional parameter with a sensible default.
+- Widens an allowed-values enum.
+- Adds new properties to a return-shape object.
+
+## Deprecation policy
+
+Before removing or renaming a public surface:
+
+1. Mark it with a `@deprecated` JSDoc tag and document the replacement.
+2. Add a `### Deprecated` entry in `CHANGELOG.md` and reference the
+   replacement.
+3. Keep the deprecated surface working for **at least one minor
+   release** before removal.
+4. Remove in the next `MAJOR` release (or pre-1.0 `MINOR` release).
+
+## Versioning policy
+
+ProjectProteus follows [Semantic Versioning 2.0.0](https://semver.org/).
+
+Pre-1.0 caveat: while the version remains `0.y.z` the Dagger module
+API may receive breaking changes in any `MINOR` bump. Downstream
+consumers should pin a specific `MINOR` until v1.0.0.
+
+## Cross-repo dispatch contract
+
+The cross-repo `repository_dispatch` payload shape (consumed in
+`cross-repo-dispatch.yml`) is **a separate contract** versioned in
+lockstep with AchaeanFleet and Myrmidons. Changes there require
+coordinated PRs across all three repos; this document does not
+govern that surface.
+
+## See also
+
+- `dagger/src/index.ts` — public surface.
+- `AGENTS.md` — cross-repo contracts.
+- `CHANGELOG.md` (once created) — release history.

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -1,0 +1,69 @@
+# Branch Protection Policy
+
+This document captures the **target** branch protection ruleset for
+ProjectProteus's default branch (`main`). The ruleset is configured in
+the GitHub UI / API by a repository admin; this file is the
+human-readable source of truth and is updated in a PR before any UI
+change.
+
+## Why this matters
+
+ProjectProteus is the CI/CD hub for the entire HomericIntelligence
+ecosystem. A regression merged directly to `main` here can fan out to
+AchaeanFleet image pushes, Myrmidons applies, and downstream agent
+provisioning. Branch protection is the last guardrail.
+
+## Target ruleset for `main`
+
+| Setting | Target value | Tracked by |
+|---|---|---|
+| Restrict deletions | **on** | — |
+| Restrict pushes (no force-pushes, no direct commits) | **on** | — |
+| Require pull request before merging | **on** | — |
+| Required approving review count | **1** (minimum) | #95 |
+| Dismiss stale approvals on new commits | **on** | — |
+| Require review from code owners | **on** | #102 |
+| Require status checks to pass | **on** | — |
+| Required status checks | see below | #94 |
+| Require branches to be up to date before merging | **on** | — |
+| Require signed commits | **off** (under review) | — |
+| Allowed merge methods | **squash only** | — |
+
+### Required status checks
+
+The following CI checks (from `.github/workflows/_required.yml`,
+`ci.yml`, `cross-repo-dispatch.yml`, and `promote.yml`) are the
+authoritative required set:
+
+- `lint-scripts` (CI / shellcheck)
+- `typecheck` (CI / `tsc --noEmit`)
+- `forbid-suppressions` (no-silent-failures guard)
+- `unit-tests` (YAML schema validation; to be replaced by real tests — #88)
+- `integration-tests` (cross-config reference check; to be expanded — #89)
+- `markdownlint` (docs lint)
+- Any future SAST / secrets-scan job once #85, #86 are fixed
+
+A required status check that does not actually run on a PR will block
+merges; whenever a check is renamed, this list must be updated in the
+same PR.
+
+## Why we are not enforcing this today
+
+The defects in #95 (zero required approvals) and #102 (CODEOWNERS not
+enforced in branch protection) are tracked separately. This document
+exists so the next maintainer with admin access can apply the policy
+in one pass without re-deriving it.
+
+## Procedure to apply
+
+1. Open repository Settings → Branches → Branch protection rules.
+2. Add or edit the rule for `main` to match the table above.
+3. Verify by issuing a no-op PR from a fork; it must require a review
+   and a green status check before the **Merge** button enables.
+4. Mark #41 / #95 / #102 / #94 closed as appropriate.
+
+## See also
+
+- `docs/milestones.md` — milestone targeting this change set
+- `CLAUDE.md` "Known Critical Defects"
+- `AGENTS.md` — cross-repo guarantees that depend on this ruleset

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -1,0 +1,71 @@
+# Milestones
+
+This document defines the **canonical milestone set** for ProjectProteus.
+Maintainers should create matching GitHub milestones in the UI and assign
+every open issue to the appropriate one. The list here is the source of
+truth; the GitHub UI mirrors it.
+
+Once the GitHub milestones exist, this file should be kept in sync as
+milestones close.
+
+## Active milestones
+
+### v0.1.x — pipeline correctness (target: 2026-06-30)
+
+Goal: make the currently-broken pipeline glue **actually work**. No new
+features — only fix the load-bearing defects identified in the
+2026-04-28 strict audit.
+
+Tracked priorities:
+
+- Fix cross-repo dispatch payload contract mismatch (#15, #84).
+- Fix build/promote tag arithmetic (#2, #83).
+- Wire the unused pipeline YAML configs into runtime code (#1, #82).
+- Replace YAML-parser "tests" with real unit and integration tests
+  (#88, #89, #5).
+- Stop suppressing security scanner failures (#85, #86).
+- Pin GitHub Actions to commit SHAs — landed.
+
+### v0.2.0 — security and reviewability (target: 2026-08-15)
+
+Goal: make Proteus safe to operate as the ecosystem's CI/CD hub.
+
+Tracked priorities:
+
+- Branch protection: require approvals (#95), enforce CODEOWNERS (#102).
+- TS error handling in Dagger module (#93).
+- Cache-aware `lint()` that doesn't `npm ci` per call (#92).
+- Dagger SDK version range tightened (#96).
+- SAST / SCA / secrets scanning truly enforcing (#23).
+
+### v0.3.0 — release engineering (target: 2026-10-15)
+
+Goal: make ProjectProteus itself releasable.
+
+Tracked priorities:
+
+- Create `CHANGELOG.md` with a real release process (#103).
+- Versioned releases (#101).
+- Devcontainer for first-time contributors — landed.
+- Operational runbooks (#116 — landed; more to follow).
+
+## Backlog (no milestone yet)
+
+Anything not in the lists above belongs in the backlog. The triage
+process (see #62) moves backlog items into a milestone once they have
+enough context.
+
+## Process
+
+- Milestones use the `v<MAJOR>.<MINOR>` naming convention.
+- A milestone is **closed** when every linked issue is closed and CI is
+  green on the matching release tag.
+- New milestones are added here by PR before being created in the
+  GitHub UI.
+
+## See also
+
+- `docs/runbooks/cross-repo-dispatch-failure.md`
+- `docs/branch-protection.md`
+- `docs/backwards-compat.md`
+- `CLAUDE.md` "Known Critical Defects"

--- a/docs/runbooks/cross-repo-dispatch-failure.md
+++ b/docs/runbooks/cross-repo-dispatch-failure.md
@@ -1,0 +1,93 @@
+# Runbook: Cross-repo dispatch failure
+
+This runbook covers the steps to diagnose and recover when ProjectProteus
+fails to deliver an apply event to Myrmidons after AchaeanFleet (or another
+upstream) emits `repository_dispatch: image-pushed`.
+
+## Symptoms
+
+- AchaeanFleet shows a successful image push, but Myrmidons does not
+  receive a corresponding apply.
+- The `Cross-Repo Dispatch` workflow on ProjectProteus shows a failed run.
+- Hosts referenced in the payload remain at the previous declarative
+  state for longer than the expected reconciliation window.
+
+## Pre-flight: confirm event reception
+
+1. Open the ProjectProteus Actions tab → `Cross-Repo Dispatch` workflow.
+2. Confirm a run was created for the suspect time window. If no run
+   exists, the inbound `repository_dispatch` was never accepted —
+   skip to "Inbound event missing" below.
+
+## Step 1 — Inspect the failed run logs
+
+1. Click the failed run.
+2. Open the `Log inbound event payload` step. Verify:
+   - `Event type` is `image-pushed`.
+   - `Client payload` contains a `host` field.
+3. If `host` is empty or missing, the contract mismatch in #15/#84 is
+   the cause. Mitigation: re-issue the upstream dispatch with the
+   payload corrected; track via the cross-repo dispatch contract issue.
+
+## Step 2 — Verify the dispatch token
+
+`scripts/dispatch-apply.sh` uses `secrets.MYRMIDONS_DISPATCH_TOKEN`.
+
+1. In repository settings → Secrets and variables → Actions, confirm
+   `MYRMIDONS_DISPATCH_TOKEN` exists and is non-expired.
+2. The token must have `repo` scope (or fine-grained `contents:write` on
+   Myrmidons). If expired, rotate via the documented secret-rotation
+   procedure and re-run the failed workflow.
+
+## Step 3 — Verify Myrmidons accepts the dispatch
+
+```bash
+gh api repos/HomericIntelligence/Myrmidons/dispatches \
+  -f event_type=apply-from-proteus \
+  -f client_payload[host]=<host>
+```
+
+(Run from a machine authenticated as the same identity backing
+`MYRMIDONS_DISPATCH_TOKEN`.)
+
+- 204 → Myrmidons accepted the event. Move on to Step 4.
+- 401/403 → token revoked or scope wrong; rotate.
+- 404 → Myrmidons repo renamed or moved; update `MYRMIDONS_REPO`
+  default in `cross-repo-dispatch.yml`.
+
+## Step 4 — Verify Myrmidons fired its Apply workflow
+
+1. Open the Myrmidons Actions tab.
+2. Look for an `Apply` run started shortly after Step 3.
+3. If no run was created, the Myrmidons-side workflow trigger is
+   misconfigured — escalate to the Myrmidons on-call.
+
+## Inbound event missing
+
+If no Proteus `Cross-Repo Dispatch` run exists at all:
+
+1. Check the upstream (AchaeanFleet) workflow logs to confirm it
+   actually called `repository_dispatch` against ProjectProteus.
+2. If the call was made and rejected, GitHub's audit log will show a
+   401/403; check whether the AchaeanFleet-side token has access.
+3. If the call was made and accepted but no run started, GitHub may
+   be lagging — wait 5 minutes, then retry.
+
+## Manual recovery
+
+Once the cause is identified, re-run by either:
+
+- Re-running the failed Proteus workflow ("Re-run all jobs"), OR
+- Re-emitting the upstream `image-pushed` dispatch from AchaeanFleet, OR
+- Manually invoking `scripts/dispatch-apply.sh <host>` from a trusted
+  shell with `MYRMIDONS_DISPATCH_TOKEN` exported (this bypasses the
+  audit trail; prefer one of the prior options).
+
+## Post-incident
+
+- File an issue documenting the root cause (token expiry, payload
+  contract drift, GitHub outage, etc.).
+- If a fix lands, link the issue and update this runbook with the
+  new diagnostic step.
+- Update `CLAUDE.md` "known critical defects" list if a new class of
+  failure was uncovered.

--- a/scripts/lib/log.sh
+++ b/scripts/lib/log.sh
@@ -1,0 +1,56 @@
+# shellcheck shell=bash
+# Structured logging helper for ProjectProteus shell scripts.
+#
+# Source this file from a script:
+#
+#   #!/usr/bin/env bash
+#   set -euo pipefail
+#   # shellcheck source=scripts/lib/log.sh
+#   source "$(dirname "$0")/lib/log.sh"
+#
+#   log_info "starting promote"
+#   log_warn "unexpected response: %s" "$resp"
+#   log_error "skopeo failed (exit %d)" "$?"
+#
+# Output is a single line per call, prefixed with an ISO-8601 timestamp,
+# the calling script's basename, and a severity level. Errors and warnings
+# go to stderr; info/debug to stdout. Output is plain text (Bash 4-safe);
+# downstream log aggregators can parse the prefix.
+
+_proteus_log_script_name() {
+  # The script that *sourced* this file.
+  basename "${BASH_SOURCE[2]:-${BASH_SOURCE[1]:-$0}}"
+}
+
+_proteus_log_ts() {
+  date -u +'%Y-%m-%dT%H:%M:%SZ'
+}
+
+_proteus_log_emit() {
+  local level="$1"; shift
+  local fd="$1"; shift
+  local fmt="$1"; shift || true
+  # shellcheck disable=SC2059
+  printf '%s level=%s script=%s message="%s"\n' \
+    "$(_proteus_log_ts)" \
+    "$level" \
+    "$(_proteus_log_script_name)" \
+    "$(printf "$fmt" "$@")" >&"$fd"
+}
+
+log_debug() {
+  [ "${LOG_LEVEL:-INFO}" = "DEBUG" ] || return 0
+  _proteus_log_emit DEBUG 1 "$@"
+}
+
+log_info() {
+  _proteus_log_emit INFO 1 "$@"
+}
+
+log_warn() {
+  _proteus_log_emit WARN 2 "$@"
+}
+
+log_error() {
+  _proteus_log_emit ERROR 2 "$@"
+}

--- a/scripts/lib/log.sh
+++ b/scripts/lib/log.sh
@@ -29,7 +29,13 @@ _proteus_log_ts() {
 _proteus_log_emit() {
   local level="$1"; shift
   local fd="$1"; shift
-  local fmt="$1"; shift || true
+  local fmt="$1"
+  # `shift` after consuming the format string may have no remaining
+  # arguments; that is intentional, so guard with a positional check
+  # rather than the forbidden `|| true` silent-failure idiom.
+  if [ "$#" -gt 0 ]; then
+    shift
+  fi
   # shellcheck disable=SC2059
   printf '%s level=%s script=%s message="%s"\n' \
     "$(_proteus_log_ts)" \


### PR DESCRIPTION
**Closes:** Closes #38. Closes #41. Closes #99. Closes #100. Closes #105. Closes #106. Closes #111. Closes #112. Closes #113. Closes #116.

---

## Summary

Bundled easy-issue sweep for ProjectProteus as part of the 2026-05-16 ecosystem-wide easy-sweep wave. 10 issues — mostly documentation, plus one mechanical SHA-pin sweep and one CI dedup. One commit per issue; bisect-friendly if CI flags anything.

## Bundled fixes

| Issue | Commit | One-line |
|---|---|---|
| #38 | `3f7c136` | ci(security): pin GitHub Actions to commit SHAs instead of mutable tags |
| #111 | `1676dda` | docs(agents): add AGENTS.md describing CI/CD coordination protocols |
| #116 | `a3de11e` | docs(runbooks): add cross-repo dispatch failure runbook |
| #112 | `f00ac70` | docs(compat): add Dagger module API backwards compatibility policy |
| #100 | `bc6ccf3` | docs(claude): document known critical defects with issue references |
| #113 | `f4345fa` | chore(devcontainer): add devcontainer with pixi, just, dagger, skopeo |
| #105 | `43abc6a` | chore(scripts): add structured logging helper scripts/lib/log.sh |
| #106 | `3f173c7` | ci(dedup): remove duplicate validate job from ci.yml |
| #99 | `e4b1ff3` | docs(milestones): define canonical milestone set with issue assignment |
| #41 | `f08f515` | docs(branch-protection): document target ruleset for default branch |

## Policy

Per `ecosystem-wide-easy-sweep` skill v1.0.0:

- **Squash-only.** This repo, like all HomericIntelligence repos, is squash-only.
- **Review required.** Do NOT use `--admin` to bypass. Do NOT enable auto-merge; bundled PRs require human review.
- **No auto-merge.** Reviewers should land this after a normal review pass.
- One commit per issue inside the bundle so a single bad commit can be reverted without dropping the bundle.

## Stale-check closures

None. All 10 EASY candidates verified open via `gh issue view --comments`; no ALREADY_DONE matches found.

## Quirks honored / discovered

- `CHANGELOG.md` empirically verified **404** via GitHub Contents API. This matches the Argus/Hermes policy-deleted pattern. Issues #103 (near-empty CHANGELOG) and #101 (no versioned releases) were classified MEDIUM by the classifier and remain in the backlog; this bundle does **not** auto-close them but does reference the release process in `docs/milestones.md`.
- pixi + pre-commit + justfile + CLAUDE.md present as expected. `--no-verify` used on every commit per the brief.
- Issue #38 (pin Actions to SHA) overlaps with the CRITICAL-severity #87 — the classifier flagged the dedupe. This bundle only closes #38; #87 remains open for the reviewer to confirm "supersedes" or close as duplicate. `actions/checkout`, `actions/setup-node`, `actions/upload-artifact`, `aquasecurity/trivy-action`, `ludeeus/action-shellcheck`, and `prefix-dev/setup-pixi` are now all SHA-pinned with `# vX.Y.Z` trailing comments matching the existing convention used in `_required.yml`.
- Issues #41 (branch protection), #99 (milestones), and `docs/branch-protection.md` define **target** state — actually toggling branch protection requires repo admin in the GitHub UI and is intentionally out-of-scope for a bundled PR.
- `docs/runbooks/cross-repo-dispatch-failure.md` references existing issue numbers (#15, #84, #2, #83, #1, #82) so the runbook stays accurate after each defect is fixed.

Branch cut from `origin/main` at clean state.

