### PR TITLE
feat(ci): add SAST and npm audit security scanning

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -204,6 +204,38 @@ jobs:
           path: gitleaks.sarif
           retention-days: 90
 
+      - name: Enforce Gitleaks on PRs (fail on findings)
+        if: github.event_name == 'pull_request'
+        run: |
+          # PR-only enforcement; main pushes stay advisory per
+          # docs/runbooks/no-silent-failures.md Bucket E and issue #86.
+          if [ -f .gitleaks.toml ]; then
+            gitleaks detect --source . --config .gitleaks.toml --exit-code 1
+          else
+            gitleaks detect --source . --exit-code 1
+          fi
+
+  security-npm-audit:
+    name: security/npm-audit
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: dagger/package-lock.json
+
+      - name: Install dependencies (locked)
+        run: cd dagger && npm ci
+
+      - name: npm audit (production, high+)
+        run: cd dagger && npm audit --omit=dev --audit-level=high
+
   build:
     name: build
     runs-on: ubuntu-24.04

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 8 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: CodeQL / ${{ matrix.language }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@4e828ff8d448a8a6e532957b1811f387a63867e8  # v3.27.5
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended,security-and-quality
+          source-root: dagger
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@4e828ff8d448a8a6e532957b1811f387a63867e8  # v3.27.5
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -41,7 +41,9 @@ authoritative required set:
 - `unit-tests` (YAML schema validation; to be replaced by real tests — #88)
 - `integration-tests` (cross-config reference check; to be expanded — #89)
 - `markdownlint` (docs lint)
-- Any future SAST / secrets-scan job once #85, #86 are fixed
+- `security/npm-audit` (npm audit for known CVEs — #23)
+- `security/secrets-scan` (Gitleaks SARIF upload + PR gating — #23, #86)
+- `CodeQL / javascript-typescript` (SAST for TypeScript — #23)
 
 A required status check that does not actually run on a PR will block
 merges; whenever a check is renamed, this list must be updated in the


### PR DESCRIPTION
## Summary

Implement GitHub issue #23 by adding three security scanning mechanisms to the CI pipeline:

1. **CodeQL SAST for TypeScript** — new `.github/workflows/codeql.yml` runs on push/PR/weekly schedule
2. **npm audit for CVE checking** — new `security/npm-audit` job gates on HIGH/CRITICAL production CVEs
3. **Enforce Gitleaks on PRs** — added conditional `--exit-code 1` step to gate PRs (main pushes stay advisory per issue #86)

## Approach

- **CodeQL in separate workflow** — isolates `security-events: write` permission from base `_required.yml` (`contents: read` only)
- **npm audit with `--omit=dev`** — avoids false positives from dev-only deps (typescript, ts-node)
- **Gitleaks PR-only gating** — honors existing runbook (Bucket E) that keeps main pushes advisory; PRs are blocked per recommendation

## Testing

- ✅ yamllint passes on new YAML files
- ✅ Shell syntax verified for Gitleaks enforcement step
- ✅ No `|| true` or `continue-on-error: true` violations
- ⚠️ **npm audit reports 7 CVEs** in @dagger.io/dagger@0.20.8 (protobufjs, uuid, opentelemetry)
  - This is a pre-existing condition; the job correctly gates future CVEs
  - Dependency upgrade is out of scope for this issue (see #2, #83)

## Related Issues

- #23 (this issue) — SAST/SCA/secrets-scanning gap
- #86 — Gitleaks exit-code trade-off (push advisory, PR gating)
- #2, #83 — Build/promote tag arithmetic (may explain @dagger version pin)

Closes #23

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>