### PR TITLE
docs(audit): add remediation plan + tracking doc (refs #81, closes #100)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,22 @@ before assuming the defect is unfixed.
 Agents must not silently work around these defects; instead, link the
 relevant issue from any PR that touches the affected code.
 
+## Audit Remediation Tracking
+
+The 2026-04-28 STRICT audit (#81) is being remediated in three waves.
+See `docs/audit-2026-04-28/remediation-plan.md` for current status of
+all 33 child issues, target dates, the wave dependency graph, and the
+pre-batched Wave 3 PR map.
+
+Agents picking up an audit child issue MUST:
+1. Read the audit context in #81 and the relevant child issue.
+2. Confirm the file target listed in `remediation-plan.md` matches the
+   actual file — security-scan jobs live in `.github/workflows/_required.yml`,
+   NOT in `.github/workflows/ci.yml`.
+3. Link the child in the PR body via `Refs #81`.
+4. Add a regression test under `tests/` (created in #88) for any bug fix.
+5. Tick the matching checkbox in `docs/audit-2026-04-28/remediation-plan.md`.
+
 ## Development Guidelines
 
 - All Dagger functions must be tested locally with `dagger call` before committing.

--- a/docs/audit-2026-04-28/remediation-plan.md
+++ b/docs/audit-2026-04-28/remediation-plan.md
@@ -1,0 +1,40 @@
+# Audit 2026-04-28 — Remediation Plan
+
+Epic: #81 | Milestone: "Audit 2026-04-28 Remediation" | Target close: 2026-07-31
+
+## External co-blockers (referenced by CLAUDE.md:92, not children of #81)
+- #89 — external test infra dependency
+- #5  — external test infra dependency
+
+## Wave 1 — Foundation (target 2026-05-31; parallel PRs)
+- [ ] #88 Test harness — adds `tests/`, `just test-suite`, vitest+bats — PR: TBD
+- [ ] #86 Gitleaks gate — `_required.yml:193,196` `--exit-code 0` → `--exit-code 1` — PR: TBD
+- [ ] #87 Action SHA pinning — VERIFY-AND-CLOSE: grep confirms all actions SHA-pinned — PR: none ✅ CLOSED
+- [ ] #94 Required status checks — branch protection API: add `typescript`, `lint-scripts`, `validate-configs`, `unit-tests` — PR: TBD
+- [ ] #95 CODEOWNERS review required — branch protection API: `required_approving_review_count=1` — PR: TBD
+- [ ] #99 Milestone created — gh API — PR: none ✅ DONE
+- [ ] #100 CLAUDE.md defect doc — covered by this PR — PR: TBD
+- [ ] #102 CODEOWNERS in branch protection — branch protection API: `require_code_owner_reviews=true` — PR: TBD
+
+## Wave 2 — Critical bugs (target 2026-06-30, gated on Wave 1 #88 merged)
+- [ ] #83 Tag arithmetic — `justfile:33` — regression test under `tests/integration/` — PR: TBD
+- [ ] #84 Dispatch payload contract — `scripts/dispatch-apply.sh` + `.github/workflows/cross-repo-dispatch.yml` — PR: TBD
+- [ ] #82 Pipeline config consumption — `dagger/src/index.ts` reads `configs/pipelines/*.yaml` — PR: TBD
+- [ ] #97 Payload `host` validation — `scripts/dispatch-apply.sh` regex check — PR: TBD
+- [ ] #93 Dagger error handling — `dagger/src/index.ts` — PR: TBD
+- [ ] #92 lint() caching — `dagger/src/index.ts` — PR: TBD
+
+## Wave 3 — Hygiene (target 2026-07-31; pre-batched PRs)
+- [ ] PR-A (`dagger/package.json`): #96, #107, #108
+- [ ] PR-B (`_required.yml`): #106
+- [ ] PR-C (`scripts/dispatch-apply.sh`): #104, #105, #98
+- [ ] PR-D (`scripts/promote-image.sh`): #109
+- [ ] PR-E (`CHANGELOG.md`): #101, #103, #112
+- [ ] PR-F (`.github/`): #110, #111, #119
+- [ ] PR-G (docs): #117, #116, #114, #121
+- [ ] PR-H (root): #113, #115, #120, #118
+- [ ] Re-audit via /hephaestus:repo-analyze-strict-full
+- [ ] Close #81 when grade ≥ B AND #82–#88 all CLOSED
+
+## Rollback policy
+Any Wave 1/2 PR that turns main CI red is reverted within 24h via `git revert`. Wave 1 #88 MUST go green on `_required.yml` before merge.


### PR DESCRIPTION
## Summary
- Create `docs/audit-2026-04-28/remediation-plan.md` with complete Wave 1/2/3 tracking
- Append "Audit Remediation Tracking" section to `CLAUDE.md` with agent checklist
- Document external co-blockers and rollback policy per approved plan

## Closes #100
This PR delivers the remediation plan and defect documentation section of #81's approved plan.

## Changes
- [x] Milestone created and attached to all 33 children (from Wave 1 implementation)
- [x] #87 verified-and-closed (GitHub Actions SHA-pinned)
- [x] #100 fixed (remediation doc + CLAUDE.md tracking section)
- [ ] Remaining Wave 1: #88 (test harness), #86 (gitleaks gate), #94/#95/#102 (branch protection)

Refs #81
Closes #100

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>