### PR TITLE
fix(ci): make gitleaks security-secrets-scan job fail on secrets

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -185,15 +185,16 @@ jobs:
 
       - name: Run Gitleaks
         run: |
-          # `--exit-code 0` makes gitleaks always exit 0 even when secrets are
-          # found; the SARIF upload (next step) is the authoritative report.
-          # See docs/runbooks/no-silent-failures.md (Bucket E).
+          # Gitleaks exits 1 on any finding (default). The SARIF upload step
+          # below uses `if: always()` so the report is preserved even when
+          # this step fails. See docs/runbooks/no-silent-failures.md.
+          set -euo pipefail
           if [ -f .gitleaks.toml ]; then
             gitleaks detect --source . --config .gitleaks.toml \
-              --report-format sarif --report-path gitleaks.sarif --exit-code 0
+              --report-format sarif --report-path gitleaks.sarif
           else
             gitleaks detect --source . \
-              --report-format sarif --report-path gitleaks.sarif --exit-code 0
+              --report-format sarif --report-path gitleaks.sarif
           fi
 
       - name: Upload Gitleaks SARIF

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,14 @@
+# Gitleaks configuration. See https://github.com/gitleaks/gitleaks for syntax.
+# This file extends the default ruleset and allowlists checked-in worktree
+# copies that mirror the main tree (and would otherwise double-report any
+# finding) plus the local build/ scratch tree.
+
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "Checked-in worktree copies and build scratch tree"
+paths = [
+  "^build/",
+  "^\\.claude/worktrees/",
+]

--- a/docs/runbooks/no-silent-failures.md
+++ b/docs/runbooks/no-silent-failures.md
@@ -1,0 +1,35 @@
+# Runbook: no silent failures in CI
+
+CI must surface real failures. Suppression patterns that hide failure
+exit codes are forbidden. The `forbid-suppressions` job in
+`.github/workflows/_required.yml` enforces this in CI.
+
+## Forbidden idioms
+
+- `<cmd> || true` at end of line (Bucket A — shell suppression).
+- `continue-on-error: true` on a workflow step or job (Bucket E —
+  workflow opt-out).
+- Tool-level zero-exit flags such as `--exit-code 0`, `--exit-zero`,
+  `--no-fail`, or `set +e` around a single command (Bucket F — tool
+  opt-out; same effect as Bucket E, different layer).
+
+## What to do instead
+
+- If the finding is real but you cannot fix it now, add the tool's
+  native allowlist (e.g. `.gitleaks.toml`, `pip-audit --ignore-vuln`,
+  `trivy --ignore-policy`) with a tracking issue and a review date.
+- If the tool is broken (wrong flag, wrong invocation), fix the
+  invocation.
+- If the step is genuinely advisory, gate it behind an explicit
+  `if`-check and emit `::warning::`, never silently exit zero.
+
+## Gitleaks specifics
+
+- Run `gitleaks detect --source . [--config .gitleaks.toml]` with no
+  `--exit-code` flag so the default exit code 1 fails the job on any
+  finding.
+- Continue to upload the SARIF artifact with `if: always()` so the
+  report is preserved even when the scan step fails.
+- For known false positives, add `[[allowlists]]` entries to
+  `.gitleaks.toml` (double-bracket array-of-tables for v8+); never
+  reintroduce `--exit-code 0`.


### PR DESCRIPTION
## Summary

- Remove `--exit-code 0` flag from gitleaks detect so job fails on any finding
- Add `.gitleaks.toml` allowlist for checked-in worktree copies and build scratch tree
- Create `docs/runbooks/no-silent-failures.md` runbook cited by the workflow

The job now blocks the pipeline when secrets are detected, with SARIF artifact preserved via `if: always()`.

Closes #86