### PR TITLE
fix(#84): implement fail-closed validation for cross-repo dispatch host contract

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -149,6 +149,15 @@ jobs:
           print(f'Validated {len(configs)} pipeline config(s)')
           " && exit 0
 
+  dispatch-contract-test:
+    name: dispatch-contract-test
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Run dispatch-apply shell tests
+        run: bash tests/dispatch-apply.test.sh
+
   security-dependency-scan:
     name: security/dependency-scan
     runs-on: ubuntu-24.04

--- a/.github/workflows/cross-repo-dispatch.yml
+++ b/.github/workflows/cross-repo-dispatch.yml
@@ -28,9 +28,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
+      - name: Require client_payload.host
+        env:
+          HOST: ${{ github.event.client_payload.host }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${HOST}" ]]; then
+            echo "::error title=dispatch-contract::client_payload.host is required but was empty or absent. See docs/dispatch-contract.md and issue #84."
+            exit 1
+          fi
+          echo "host=${HOST}" >> "$GITHUB_ENV"
+
       - name: Dispatch apply to Myrmidons
         env:
           GITHUB_TOKEN: ${{ secrets.MYRMIDONS_DISPATCH_TOKEN }}
           MYRMIDONS_REPO: HomericIntelligence/Myrmidons
-          HOST: ${{ github.event.client_payload.host }}
-        run: ./scripts/dispatch-apply.sh "$HOST"
+        run: ./scripts/dispatch-apply.sh "${{ env.host }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,10 +42,9 @@ client_payload:
 ProjectProteus reads `client_payload.host` in
 `.github/workflows/cross-repo-dispatch.yml` and invokes
 `scripts/dispatch-apply.sh` to forward the apply request to Myrmidons.
-
-The contract for `client_payload` is currently under-specified — see
-the issue backlog for the payload contract mismatch (#15, #84) and the
-known-defects list in `CLAUDE.md`.
+`host` is REQUIRED — the workflow fails closed with `::error::` if it is
+absent (issue #84). The full payload contract lives in
+`docs/dispatch-contract.md`. Upstream emitter alignment is tracked in #15.
 
 ## Outbound handoff (Proteus → Myrmidons)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,9 +79,11 @@ this repo should know about them before changing behaviour in the
 affected areas. Always check the linked issue for the current status
 before assuming the defect is unfixed.
 
-- **Cross-repo dispatch payload contract mismatch.** `cross-repo-dispatch.yml`
-  reads `client_payload.host`, but no documented upstream emitter currently
-  sends that field consistently. See #15, #84.
+- **Cross-repo dispatch payload contract.** `cross-repo-dispatch.yml`
+  treats `client_payload.host` as REQUIRED and the workflow fails closed
+  with `::error::` if it is absent (#84). Upstream alignment so
+  AchaeanFleet actually emits `host` is tracked in #15; this entry stays
+  until that lands. Canonical schema: `docs/dispatch-contract.md`.
 - **Build/promote tag arithmetic broken.** The build and promote scripts
   produce incorrect tags in edge cases (multi-arch, no-tag input). See
   #2, #83.

--- a/docs/dispatch-contract.md
+++ b/docs/dispatch-contract.md
@@ -1,0 +1,68 @@
+# Cross-Repo Dispatch Contract
+
+This document specifies the contract for `repository_dispatch` events flowing between homericintelligence repos and ProjectProteus.
+
+## Inbound: AchaeanFleet → ProjectProteus (`image-pushed`)
+
+AchaeanFleet sends `image-pushed` events to ProjectProteus when a new OCI image is built and pushed to a registry.
+
+| Field | Type | Required | Consumed At | Notes |
+|-------|------|----------|-------------|-------|
+| `host` | string | **REQUIRED** | `.github/workflows/cross-repo-dispatch.yml:36` | Target host for `agamemnon-apply` dispatch. If absent, missing, or empty, the `Require client_payload.host` step fails the workflow with `::error::` — see issue #84. |
+| `image` | string | No | Not consumed | Advisory field; documented in `AGENTS.md:38-40`. Future consumers should normalize via `docs/dispatch-contract.md`. |
+| `tag` | string | No | Not consumed | Advisory field; documented in `AGENTS.md:38-40`. Future consumers should normalize via `docs/dispatch-contract.md`. |
+| `image_tag` | string | No | Not consumed | Advisory field; documented in `AGENTS.md:38-40`. Future consumers should normalize via `docs/dispatch-contract.md`. |
+| `source` | string | No | Not consumed | Advisory field; documented in `AGENTS.md:38-40`. Future consumers should normalize via `docs/dispatch-contract.md`. |
+
+**Source of truth**: AchaeanFleet's `notify-proteus.sh` script.
+
+## Outbound: ProjectProteus → Myrmidons (`agamemnon-apply`)
+
+ProjectProteus forwards the dispatch to Myrmidons with the following event:
+
+```json
+{
+  "event_type": "agamemnon-apply",
+  "client_payload": {
+    "host": "<host-from-inbound>"
+  }
+}
+```
+
+**Sent by**: `scripts/dispatch-apply.sh:25`.
+
+## Fail-Closed Behavior
+
+If `host` is absent, missing, or empty in the inbound payload, ProjectProteus **fails closed**:
+
+1. `.github/workflows/cross-repo-dispatch.yml:36` — the `Require client_payload.host` step detects the condition and logs `::error title=dispatch-contract::`.
+2. The step exits with code 1, halting the workflow.
+3. No `agamemnon-apply` dispatch is sent to Myrmidons.
+
+**Rationale**: In multi-host deployments, a silent default to any host (e.g., `hermes`) would misroute applies and corrupt cluster state. Failing closed ensures operators must explicitly provide `host`; see issue #84.
+
+## Local Verification
+
+To verify the inbound contract with a test dispatch:
+
+```bash
+# Send a known-good payload (with host):
+gh api repos/HomericIntelligence/ProjectProteus/dispatches \
+  -f event_type=image-pushed \
+  -f client_payload='{"host":"hermes","image":"myapp","tag":"1.0.0"}'
+
+# Send a failing payload (missing host):
+gh api repos/HomericIntelligence/ProjectProteus/dispatches \
+  -f event_type=image-pushed \
+  -f client_payload='{"image":"myapp","tag":"1.0.0"}'
+# Expected: workflow run fails with ::error title=dispatch-contract:: annotation.
+```
+
+## Related Issues & Documents
+
+- **Issue #84**: Fix the `host` field mismatch (this PR).
+- **Issue #15**: Coordinate AchaeanFleet emitter to ensure `host` is always sent.
+- **`AGENTS.md:38-40`**: Advisory fields and future normalization.
+- **`.github/workflows/cross-repo-dispatch.yml`**: Inbound validation and dispatch.
+- **`scripts/dispatch-apply.sh`**: Outbound dispatch to Myrmidons.
+- **`docs/runbooks/cross-repo-dispatch-failure.md`**: Troubleshooting guide.

--- a/docs/runbooks/cross-repo-dispatch-failure.md
+++ b/docs/runbooks/cross-repo-dispatch-failure.md
@@ -25,9 +25,11 @@ upstream) emits `repository_dispatch: image-pushed`.
 2. Open the `Log inbound event payload` step. Verify:
    - `Event type` is `image-pushed`.
    - `Client payload` contains a `host` field.
-3. If `host` is empty or missing, the contract mismatch in #15/#84 is
-   the cause. Mitigation: re-issue the upstream dispatch with the
-   payload corrected; track via the cross-repo dispatch contract issue.
+3. If `host` is empty or missing, the `Require client_payload.host` step
+   will have failed with an `::error title=dispatch-contract::` annotation
+   (issue #84). This is intentional fail-closed behavior — no apply is
+   dispatched. Mitigation: re-issue the upstream dispatch with `host` set,
+   per `docs/dispatch-contract.md`.
 
 ## Step 2 — Verify the dispatch token
 

--- a/scripts/dispatch-apply.sh
+++ b/scripts/dispatch-apply.sh
@@ -1,13 +1,19 @@
 #!/usr/bin/env bash
 # dispatch-apply.sh — Send a repository_dispatch event to trigger Myrmidons apply.
-# Usage: HOST=hermes GITHUB_TOKEN=<token> MYRMIDONS_REPO=HomericIntelligence/Myrmidons \
+# Usage: HOST=<host> GITHUB_TOKEN=<token> MYRMIDONS_REPO=HomericIntelligence/Myrmidons \
 #            ./scripts/dispatch-apply.sh [host]
 # The HOST argument overrides the HOST env var if both are provided.
+# If neither is set, the script FAILS CLOSED (exits 1) — see docs/dispatch-contract.md.
 
 set -euo pipefail
 
-HOST="${1:-${HOST:-hermes}}"
+HOST="${1:-${HOST:-}}"
 MYRMIDONS_REPO="${MYRMIDONS_REPO:-HomericIntelligence/Myrmidons}"
+
+if [[ -z "${HOST}" ]]; then
+    echo "Error: host is required (pass as \$1 or set HOST env var). See docs/dispatch-contract.md (#84)." >&2
+    exit 1
+fi
 
 if [[ -z "${GITHUB_TOKEN:-}" ]]; then
     echo "Error: GITHUB_TOKEN is required." >&2

--- a/tests/dispatch-apply.test.sh
+++ b/tests/dispatch-apply.test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Tests for scripts/dispatch-apply.sh
+# Verifies: explicit host argument, HOST env var, fail-closed behavior
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SHIM_DIR="$(mktemp -d)"
+trap 'rm -rf "$SHIM_DIR"' EXIT
+
+# Create a curl shim that returns 204 No Content (success response)
+cat >"$SHIM_DIR/curl" <<'EOF'
+#!/usr/bin/env bash
+# Stub for tests/dispatch-apply.test.sh — echoes a 204 in the format
+# scripts/dispatch-apply.sh:19 expects (body then HTTP code on the last line).
+printf '\n204\n'
+EOF
+chmod +x "$SHIM_DIR/curl"
+
+export PATH="$SHIM_DIR:$PATH"
+export GITHUB_TOKEN="fake-token-for-test"
+export MYRMIDONS_REPO="HomericIntelligence/Myrmidons"
+
+# Case 1: explicit host argument — exits 0, prints host in output.
+out=$("$REPO_ROOT/scripts/dispatch-apply.sh" multihost-a 2>&1)
+echo "$out" | grep -q "for host: multihost-a" \
+  || { echo "FAIL case1: expected 'for host: multihost-a' in output"; echo "$out"; exit 1; }
+
+# Case 2: HOST env var set, no argument — exits 0, prints HOST in output.
+unset HOST || true
+out=$(env HOST=multihost-b "$REPO_ROOT/scripts/dispatch-apply.sh" 2>&1)
+echo "$out" | grep -q "for host: multihost-b" \
+  || { echo "FAIL case2: expected 'for host: multihost-b' in output"; echo "$out"; exit 1; }
+
+# Case 3: NO host (neither arg nor env) — must FAIL CLOSED with nonzero exit.
+unset HOST || true
+if "$REPO_ROOT/scripts/dispatch-apply.sh" 2>err.txt; then
+  echo "FAIL case3: expected nonzero exit, got 0"; cat err.txt; exit 1
+fi
+grep -q "host is required" err.txt \
+  || { echo "FAIL case3: expected 'host is required' in stderr"; cat err.txt; exit 1; }
+
+echo "OK: all 3 cases passed"


### PR DESCRIPTION
## Summary

Fixes issue #84 by implementing fail-closed validation for the `host` field in cross-repo dispatch payloads.

- **Root cause**: `cross-repo-dispatch.yml` reads `client_payload.host`, but AchaeanFleet never sends it, causing silent fallback to `hermes` — which silently misroutes applies in multi-host deployments.
- **Solution**: Fail closed (exit 1 + ::error::) when `host` is missing, with comprehensive test coverage and contract documentation.

## Changes

- `scripts/dispatch-apply.sh`: Eliminate silent `${HOST:-hermes}` default; exit 1 if host is missing
- `.github/workflows/cross-repo-dispatch.yml`: Add "Require client_payload.host" step before dispatch
- `.github/workflows/_required.yml`: Add `dispatch-contract-test` job to exercise fail-closed path
- `tests/dispatch-apply.test.sh`: Test suite covering explicit arg, env var, and fail-closed cases
- `docs/dispatch-contract.md`: Canonical schema for inbound/outbound dispatch contract
- `AGENTS.md`, `CLAUDE.md`, `docs/runbooks/cross-repo-dispatch-failure.md`: Updated to reflect fail-closed semantics

All tests pass; YAML validates; cross-references verified.

Closes #84