### PR TITLE
feat: [MAJOR] §4: lint() runs npm ci in container on every call — non-cacheable and self-referential

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
         with:
           scandir: "./scripts"
 
+      - name: Verify issue #92 invariants
+        run: bash scripts/verify-issue-92-invariants.sh
+
   typecheck:
     name: TypeScript Type Check
     runs-on: ubuntu-latest

--- a/dagger/src/index.ts
+++ b/dagger/src/index.ts
@@ -75,27 +75,37 @@ export class Proteus {
 
   /**
    * Run tsc type-check against the Dagger TypeScript sources.
-   * Returns tsc output.
+   * Mounts only the dagger/ subdirectory (not the full repo) and caches the
+   * npm download cache across invocations via a Dagger cache volume.
+   * node_modules is recreated each run by npm ci (by design). Fixes #92.
    */
   @func()
   async lintTsc(source: Directory): Promise<string> {
+    const daggerDir = source.directory("dagger")
     return dag
       .container()
       .from("node:20-alpine")
-      .withMountedDirectory("/src", source)
-      .withWorkdir("/src/dagger")
-      .withExec(["sh", "-c", "npm ci && npx tsc --noEmit"])
+      .withMountedCache("/root/.npm", dag.cacheVolume("proteus-npm-cache"))
+      .withWorkdir("/work")
+      .withFile("/work/package.json", daggerDir.file("package.json"))
+      .withFile("/work/package-lock.json", daggerDir.file("package-lock.json"))
+      .withExec(["npm", "ci", "--prefer-offline", "--no-audit"])
+      .withMountedDirectory("/work/src", daggerDir.directory("src"))
+      .withFile("/work/tsconfig.json", daggerDir.file("tsconfig.json"))
+      .withExec(["npx", "tsc", "--noEmit"])
       .stdout()
   }
 
   /**
    * Run all lint checks against the source directory (shellcheck + tsc).
-   * Returns combined lint output.
+   * Returns a JSON object with keys 'shellcheck' and 'tsc', each containing
+   * the respective linter output. Callers wanting a single linter should call
+   * lintShellcheck() or lintTsc() directly. Fixes #92.
    */
   @func()
   async lint(source: Directory): Promise<string> {
     const shellcheck = await this.lintShellcheck(source)
     const tsc = await this.lintTsc(source)
-    return `=== shellcheck ===\n${shellcheck}\n=== tsc ===\n${tsc}`
+    return JSON.stringify({ shellcheck, tsc }, null, 2)
   }
 }

--- a/justfile
+++ b/justfile
@@ -65,6 +65,10 @@ bootstrap:
 lint:
     dagger call lint --source .
 
+# Static check that issue #92's lintTsc invariants are still present
+lint-verify-92:
+    bash scripts/verify-issue-92-invariants.sh
+
 # Run lint + validate together
 check: lint validate
 

--- a/scripts/verify-issue-92-invariants.sh
+++ b/scripts/verify-issue-92-invariants.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Asserts the three invariants from issue #92 are still present in
+# dagger/src/index.ts. Runs as a static source-code check (no Dagger
+# invocation, no timing).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+src="dagger/src/index.ts"
+
+fail=0
+
+# Invariant 1: lintTsc mounts an npm cache volume named proteus-npm-cache.
+if ! grep -qE 'withMountedCache\("/root/\.npm", dag\.cacheVolume\("proteus-npm-cache"\)\)' "$src"; then
+  echo "FAIL[#92 inv-1]: npm cache mount missing in $src" >&2
+  fail=1
+fi
+
+# Invariant 2: lintTsc narrows source to dagger/ (not the whole repo).
+# Pull the lintTsc body and assert it (a) calls source.directory("dagger")
+# and (b) does NOT mount the full source under /src.
+lint_tsc_body=$(awk '/async lintTsc\(/,/^  \}/' "$src")
+if ! grep -q 'source.directory("dagger")' <<<"$lint_tsc_body"; then
+  echo "FAIL[#92 inv-2a]: lintTsc no longer narrows to dagger/" >&2
+  fail=1
+fi
+if grep -q 'withMountedDirectory("/src", source)' <<<"$lint_tsc_body"; then
+  echo "FAIL[#92 inv-2b]: lintTsc re-introduced full-repo /src mount" >&2
+  fail=1
+fi
+
+# Invariant 3: lint() returns a structured JSON object, not concatenated text.
+if ! grep -qE 'JSON\.stringify\(\{ ?shellcheck, ?tsc ?\}' "$src"; then
+  echo "FAIL[#92 inv-3]: lint() output is no longer structured JSON" >&2
+  fail=1
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+  exit 1
+fi
+echo "OK: all issue #92 invariants present in $src"


### PR DESCRIPTION
## Summary
Implements #92

## Changes
- Automated implementation via Claude Code

## Testing
- Automated tests included

## Closes
Closes #92

Generated with [Claude Code](https://claude.com/claude-code)
